### PR TITLE
Change find() for children() when unwrapping.

### DIFF
--- a/angular-blaze-template.js
+++ b/angular-blaze-template.js
@@ -19,7 +19,7 @@ angularMeteorTemplate.directive('blazeTemplate', [
             var viewHandler = Blaze.renderWithData(template, scope, element[0]);
             $compile(element.contents())(scope);
 
-            element.find().unwrap();
+            element.children().unwrap();
 
             scope.$on('$destroy', function() {
               Blaze.remove(viewHandler);


### PR DESCRIPTION
find() method retrieves an empty list when no selector is defined, while children() properly retrieves the children of the element
