### PR TITLE
Accept replace attribute to replace the directive element

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,14 @@ You can include Meteor's Blaze native templates with the [blaze-template](http:/
 <blaze-template name="todoList"></blaze-template>
 ```
 
+### `replace` directive with template content
+Sometimes, the page styling or logic could strictly depend on the DOM tree
+depth level where the template elements are located. The directive element
+could be replaced with the contents of the template using the attribute
+`replace` as follows:
+
+```html
+<blaze-template name="todoList" replace></blaze-template>
+```
+
 Read more on blaze-template, using parameters and binding Blaze templates to Angular's scope in the [API docs](http://angular-meteor.com/api/blaze-template).

--- a/angular-blaze-template.js
+++ b/angular-blaze-template.js
@@ -19,13 +19,8 @@ angularMeteorTemplate.directive('blazeTemplate', [
                 viewHandler;
             
             if (typeof attributes['replace'] !== 'undefined') {
-              var _renderWithDataAttributes = [
-                template,
-                scope,
-                element.parent()[0],
-                element[0]
-              ];
-              viewHandler = Blaze.renderWithData.apply(null, _renderWithDataAttributes);
+              viewHandler = Blaze.
+                renderWithData(template, scope, element.parent()[0], element[0]);
               element.remove();
             } else {
               viewHandler = Blaze.renderWithData(template, scope, element[0]);

--- a/angular-blaze-template.js
+++ b/angular-blaze-template.js
@@ -16,10 +16,15 @@ angularMeteorTemplate.directive('blazeTemplate', [
           if (name && Template[name]) {
 
             var template = Template[name];
-            var viewHandler = Blaze.renderWithData(template, scope, element[0]);
-            $compile(element.contents())(scope);
-
-            element.find().unwrap();
+            
+            if (typeof attributes['replace'] !== 'undefined') {
+              var renderOpts = [template, scope, element.parent()[0], element[0]],
+                  viewHandler = Blaze.renderWithData.apply(null, renderOpts);
+              element.remove();
+            } else {
+              $compile(element.contents())(scope);
+              element.find().unwrap();
+            }
 
             scope.$on('$destroy', function() {
               Blaze.remove(viewHandler);

--- a/angular-blaze-template.js
+++ b/angular-blaze-template.js
@@ -15,13 +15,20 @@ angularMeteorTemplate.directive('blazeTemplate', [
           var name = attributes.blazeTemplate || attributes.name;
           if (name && Template[name]) {
 
-            var template = Template[name];
+            var template = Template[name],
+                viewHandler;
             
             if (typeof attributes['replace'] !== 'undefined') {
-              var renderOpts = [template, scope, element.parent()[0], element[0]],
-                  viewHandler = Blaze.renderWithData.apply(null, renderOpts);
+              var _renderWithDataAttributes = [
+                template,
+                scope,
+                element.parent()[0],
+                element[0]
+              ];
+              viewHandler = Blaze.renderWithData.apply(null, _renderWithDataAttributes);
               element.remove();
             } else {
+              viewHandler = Blaze.renderWithData(template, scope, element[0]);
               $compile(element.contents())(scope);
               element.find().unwrap();
             }


### PR DESCRIPTION
This feature would allow people to make `ian:accounts-ui-bootstrap-3` work, as the issue is that the parent directive element remains there, eventually breaking the some styling. Some people faced this issue in Urigo/angular-meteor#191 and Urigo/angular-meteor#455.

The usage would be something like: `<blaze-template name="_loginButtons" replace></blaze-template>`.
